### PR TITLE
update: add Adapt role, close Postman, publish blog post

### DIFF
--- a/src/assets/work.yaml
+++ b/src/assets/work.yaml
@@ -1,9 +1,19 @@
+- title: VP of Product & Engineering
+  location: San Francisco, CA
+  employer: Adapt
+  logo: ./logos/adapt.svg
+  date: "2026-Present"
+  description: I lead Product & Engineering at Adapt, a seed-stage startup building the AI-native operating system for teams. Adapt connects to the tools your team already uses and gives you a single interface to ask questions, take action, and automate workflows across all of them.
+  highlights:
+    - Building and leading the Product & Engineering teams from the ground up at seed stage
+    - Shaping the product vision and roadmap for an AI-native platform used by teams to automate work across their entire tool stack
+    - Writing code and setting the technical and cultural bar for the engineering organization
 - title: Head of API Client
   location: San Francisco, CA
   employer: Postman
   logo: ./logos/postman.svg
-  date: "2023-Present"
-  description: I lead the team that owns the central engine of the Postman product in the API Client. Postman is one of the world's most loved and ubiquitous developer tools. The API Client team is responsible for maintaining and improving the core functionality of enabling developers to send, debug, and test requests across multiple protocols (REST, gRPC, Websockets, GraphQL, MQTT, AI models, and MCP). Postman is a Series D startup that has millions of daily users and strong triple-digit millions in revenue.
+  date: "2023-2026"
+  description: I led the team that owns the central engine of the Postman product in the API Client. Postman is one of the world's most loved and ubiquitous developer tools. The API Client team is responsible for maintaining and improving the core functionality of enabling developers to send, debug, and test requests across multiple protocols (REST, gRPC, Websockets, GraphQL, MQTT, AI models, and MCP). Postman is a Series D startup that has millions of daily users and strong triple-digit millions in revenue.
   highlights:
     - Modernized the core API client, making it simpler, faster, and more feature rich, addressing the longest-standing user-reported issues ([HTTP/2 support](https://github.com/postmanlabs/postman-app-support/issues/2701), [prompting for variables](https://github.com/postmanlabs/postman-app-support/issues/285), [SOCKS5 Proxy](https://github.com/postmanlabs/postman-app-support/issues/1321) and many more)
     - Launched two new protocols from zero to thousands of users with AI request and MCP request

--- a/src/components/header/header.module.css
+++ b/src/components/header/header.module.css
@@ -31,7 +31,7 @@
 
 .employer {
   text-decoration: none;
-  color: var(--postman-color);
+  color: var(--adapt-color);
 }
 
 .employer:hover {

--- a/src/components/header/header.tsx
+++ b/src/components/header/header.tsx
@@ -1,5 +1,5 @@
 import styles from './header.module.css'
-import logo from '@/assets/logos/postman.svg'
+import logo from '@/assets/logos/adapt.svg'
 
 interface Props {
   commits: number;
@@ -20,7 +20,7 @@ export function Header({ commits, showCopy = true, copy: customizedCopy, byline:
   )
   const byline = customizedByline ? customizedByline : (
     <>
-      Product & Engineering Leader at <a className={styles.employer} href="https://getpostman.com" target="_blank"><img className={styles.logo} src={logo.src} alt="The logo of my employer Postman, an API Platform and REST Client" /> Postman</a>
+      Product & Engineering Leader at <a className={styles.employer} href="https://adapt.com" target="_blank"><img className={styles.logo} src={logo.src} alt="The logo of my employer Adapt, an AI-native operating system for teams" /> Adapt</a>
     </>
   )
   return (

--- a/src/content/posts/2026-04-13-joining-adapt/index.md
+++ b/src/content/posts/2026-04-13-joining-adapt/index.md
@@ -3,7 +3,6 @@ date: 2026-04-13
 title: "Joining Adapt"
 author: Dustin Schau
 featured: false
-draft: true
 excerpt: "I'm joining Adapt to lead Product & Engineering. Here's why."
 tags:
   - career

--- a/src/pages/work.astro
+++ b/src/pages/work.astro
@@ -6,6 +6,7 @@ import work from '@/assets/work.yaml'
 
 import { Company } from '@/components/company/company.tsx'
 
+import adapt from '@/assets/logos/adapt.svg'
 import postman from '@/assets/logos/postman.svg'
 import netlify from '@/assets/logos/netlify.svg'
 import gatsby from '@/assets/logos/gatsby.svg'
@@ -19,6 +20,7 @@ import { marked } from 'marked'
 export const prerender = true
 
 const LOGOS: { [key: string]: ImageMetadata } = {
+	'Adapt': adapt,
 	'Postman': postman,
 	'Netlify': netlify,
 	'Gatsby': gatsby,

--- a/src/styles/companies.css
+++ b/src/styles/companies.css
@@ -1,9 +1,14 @@
 :root {
+  --adapt-color: #0f0e0e;
   --postman-color: rgb(255, 108, 55);
   --netlify-color: rgb(1, 72, 71);
   --gatsby-color: rebeccapurple;
   --opi-color: #d22630;
   --up-color: rgb(0, 82, 155);
+}
+
+.adapt {
+  color: var(--adapt-color);
 }
 
 .postman {


### PR DESCRIPTION
## Summary

- Adds VP of Product & Engineering at Adapt (2026-Present) to work history
- Closes out Postman role with end date (2023-2026), updates description to past tense
- Publishes the "Joining Adapt" blog post by removing the `draft` flag

## Note

`src/assets/logos/adapt.svg` still needs to be added — the work page will reference it but the logo won't render until that file exists.

## Test plan

- [ ] Visit `/work` and confirm Adapt appears as the current role above Postman
- [ ] Confirm Postman shows "2023-2026" date range
- [ ] Visit `/posts/joining-adapt` and confirm the post is publicly accessible
- [ ] Add `adapt.svg` to `src/assets/logos/` before merging

🤖 Generated with [Claude Code](https://claude.com/claude-code)